### PR TITLE
Add Docker support for MCP server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,58 @@
+# Git
+.git
+.gitignore
+
+# Python
+__pycache__
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual environments
+.env
+.venv
+env/
+venv/
+ENV/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+.tox/
+.nox/
+
+# Documentation
+docs/_build/
+
+# Docker
+Dockerfile
+docker-compose*.yml
+.dockerignore
+
+# Misc
+*.md
+LICENSE
+.env.example

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+FROM python:3.12-slim
+
+# Install system dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        curl \
+        ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install uv for fast Python package management
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH="/root/.local/bin:${PATH}"
+
+WORKDIR /app
+
+# Copy dependency files first for better caching
+COPY requirements.txt pyproject.toml ./
+
+# Install dependencies
+RUN uv pip install --system -r requirements.txt
+
+# Copy application code
+COPY src/ ./src/
+
+# Install the package in editable mode
+RUN uv pip install --system -e .
+
+# Environment variables (can be overridden at runtime)
+ENV SURE_API_URL=""
+ENV SURE_API_KEY=""
+ENV SURE_TIMEOUT="30"
+ENV SURE_VERIFY_SSL="true"
+
+# Run the MCP server using stdio transport
+CMD ["python", "-m", "sure_mcp_server.server"]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,50 @@ A Model Context Protocol (MCP) server for integrating with the [Sure](https://gi
 
 ## Quick Start
 
-### 1. Installation
+There are two ways to run the Sure MCP Server: **Docker (recommended)** or **manual installation**.
+
+### Option A: Docker Installation (Recommended)
+
+1. **Build the Docker image**:
+   ```bash
+   docker build -t sure-mcp-server .
+   ```
+
+2. **Configure Claude Desktop** to use Docker:
+
+   **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+
+   **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+
+   ```json
+   {
+     "mcpServers": {
+       "Sure": {
+         "command": "docker",
+         "args": [
+           "run",
+           "-i",
+           "--rm",
+           "-e", "SURE_API_URL",
+           "-e", "SURE_API_KEY",
+           "-e", "SURE_VERIFY_SSL=false",
+           "--add-host=host.docker.internal:host-gateway",
+           "sure-mcp-server"
+         ],
+         "env": {
+           "SURE_API_URL": "http://host.docker.internal:3000",
+           "SURE_API_KEY": "your-api-key-here"
+         }
+       }
+     }
+   }
+   ```
+
+   **Note**: Use `host.docker.internal` to connect to Sure running on your host machine.
+
+3. **Restart Claude Desktop**
+
+### Option B: Manual Installation
 
 1. **Clone this repository**:
    ```bash
@@ -53,14 +96,14 @@ A Model Context Protocol (MCP) server for integrating with the [Sure](https://gi
 
 4. **Restart Claude Desktop**
 
-### 2. Get Your Sure API Key
+### Get Your Sure API Key
 
 1. Start your Sure Docker instance: `docker compose up -d`
 2. Log into Sure at `http://localhost:3000`
 3. Go to **Settings > API Key** and generate a new key
 4. Copy the API key to your Claude Desktop config
 
-### 3. Start Using in Claude Desktop
+### Start Using in Claude Desktop
 
 Once configured, use these tools directly in Claude Desktop:
 - `get_accounts` - View all accounts

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  sure-mcp-server:
+    build: .
+    image: sure-mcp-server:latest
+    container_name: sure-mcp-server
+    stdin_open: true
+    tty: true
+    environment:
+      - SURE_API_URL=${SURE_API_URL:-http://host.docker.internal:3000}
+      - SURE_API_KEY=${SURE_API_KEY}
+      - SURE_TIMEOUT=${SURE_TIMEOUT:-30}
+      - SURE_VERIFY_SSL=${SURE_VERIFY_SSL:-false}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    restart: unless-stopped


### PR DESCRIPTION
- Add Dockerfile with Python 3.12 and uv package manager
- Add docker-compose.yml for easy local development
- Add .dockerignore to optimize build context
- Update README with Docker installation instructions

Addresses issue #1: Package with Docker